### PR TITLE
Proposal - Change Voting Delay

### DIFF
--- a/src/test/proposals/21.sol
+++ b/src/test/proposals/21.sol
@@ -1,0 +1,27 @@
+pragma solidity ^0.6.7;
+pragma experimental ABIEncoderV2;
+
+import "../SimulateProposalBase.t.sol";
+
+contract Proposal21Test is SimulateProposalBase {
+    function test_proposal_21() public onlyFork {
+        uint256 currentVotingDelay = 1;
+        uint256 newVotingDelay = 5760; // 24 hours in 15 second blocks
+
+        assertEq(governor.votingDelay(), currentVotingDelay);
+
+        address[] memory targets = new address[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        targets[0] = address(governor);
+         calldatas[0] = abi.encodeWithSelector(
+            bytes4(keccak256("_setVotingDelay(uint256)")),
+            newVotingDelay
+        );
+
+        _passProposal(targets, calldatas);
+
+        assertEq(governor.votingDelay(), newVotingDelay);
+    }
+
+}

--- a/src/test/proposals/21.sol
+++ b/src/test/proposals/21.sol
@@ -6,16 +6,17 @@ import "../SimulateProposalBase.t.sol";
 contract Proposal21Test is SimulateProposalBase {
     function test_proposal_21() public onlyFork {
         uint256 currentVotingDelay = 1;
-        uint256 newVotingDelay = 5760; // 24 hours in 15 second blocks
+        uint256 newVotingDelay = 6600; // 22 hours in 12 second blocks (this is max delay allowed)
 
         assertEq(governor.votingDelay(), currentVotingDelay);
 
         address[] memory targets = new address[](1);
         bytes[] memory calldatas = new bytes[](1);
 
-        targets[0] = address(governor);
+        targets[0] = govActions;
         calldatas[0] = abi.encodeWithSelector(
-            bytes4(keccak256("_setVotingDelay(uint256)")),
+            bytes4(keccak256("_setVotingDelay(address,uint256)")),
+            address(governor),
             newVotingDelay
         );
 

--- a/src/test/proposals/21.sol
+++ b/src/test/proposals/21.sol
@@ -14,7 +14,7 @@ contract Proposal21Test is SimulateProposalBase {
         bytes[] memory calldatas = new bytes[](1);
 
         targets[0] = address(governor);
-         calldatas[0] = abi.encodeWithSelector(
+        calldatas[0] = abi.encodeWithSelector(
             bytes4(keccak256("_setVotingDelay(uint256)")),
             newVotingDelay
         );
@@ -23,5 +23,4 @@ contract Proposal21Test is SimulateProposalBase {
 
         assertEq(governor.votingDelay(), newVotingDelay);
     }
-
 }


### PR DESCRIPTION
Change the number of blocks before voting begins after a proposal is submitted.