### PR TITLE
Proposal 32: Remove old Tellor oracle

### DIFF
--- a/src/test/proposals/32.sol
+++ b/src/test/proposals/32.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.6.7;
+pragma experimental ABIEncoderV2;
+
+import "../SimulateProposalBase.t.sol";
+
+contract Proposal32Test is SimulateProposalBase {
+    function test_proposal_32() public onlyFork {
+
+        address[] memory targets = new address[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        address oracleOverlay = 0xBf26309B0BA639ABE651dd1e1042Eb3C57c3e100;
+
+        targets[0] = govActions;
+        calldatas[0] = abi.encodeWithSignature(
+            "executeChange(address)",
+            oracleOverlay
+        );
+
+        // propose / execute proposal
+        _passProposal(targets, calldatas);
+    }
+}


### PR DESCRIPTION
Remove the old Tellor oracle once the newly added one is executed. Newly added PR: https://github.com/reflexer-labs/geb-dao-governance-actions/pull/29

Notes:
1. This proposal is 32 to leave room for 31 that will be sued to execute May 2023 incentives.
