### PR TITLE
Proposal 32: Remove old Tellor oracle

### DIFF
--- a/src/test/proposals/32.sol
+++ b/src/test/proposals/32.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.6.7;
+pragma experimental ABIEncoderV2;
+
+import "../SimulateProposalBase.t.sol";
+
+contract Proposal32Test is SimulateProposalBase {
+    function test_proposal_32() public onlyFork {
+
+        address[] memory targets = new address[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        address oracleOverlay = 0xBf26309B0BA639ABE651dd1e1042Eb3C57c3e100;
+
+        targets[0] = govActions;
+        calldatas[0] = abi.encodeWithSignature(
+            "executeChange(address)",
+            oracleOverlay
+        );
+
+        // propose / execute proposal
+        _passProposal(targets, calldatas);
+    }
+}

--- a/src/test/proposals/32.sol
+++ b/src/test/proposals/32.sol
@@ -3,6 +3,16 @@ pragma experimental ABIEncoderV2;
 
 import "../SimulateProposalBase.t.sol";
 
+
+
+abstract contract OSMLike {
+    function currentOracle() external view virtual returns (address);
+    function read() virtual external view returns (uint256);
+    function trustedOracles(uint256) external view virtual returns (uint256);
+}
+
+enum ChangeType {Add, Remove, Replace}
+
 contract Proposal32Test is SimulateProposalBase {
     function test_proposal_32() public onlyFork {
 
@@ -11,10 +21,41 @@ contract Proposal32Test is SimulateProposalBase {
 
         address oracleOverlay = 0xBf26309B0BA639ABE651dd1e1042Eb3C57c3e100;
 
+        address updatedTellorOracle = 0x58881e5bbecA2F1186921Ae86149edaCc717429A;
+        address oldTellorOracle = 0x2c88408E036B7d0B015B92862c9D93197C72775C;
+
+        OSMLike osm = OSMLike(oracleOverlay);
+
+        uint readValue = osm.read();
+        address currentItem = osm.currentOracle();
+
+        // uint oracleCount = osm.trustedOracles().length;
+        // address[] memory trustedOracles = osm.trustedOracles();
+        // address[] memory trustedOracles;
+        uint currentOracle = osm.trustedOracles(1);
+
+
+        
+
+        // trustedOracles = osm.trustedOracles();
+
+        log_named_uint("readValue", readValue);
+        log_named_uint("currentOracle", currentOracle);
+        
+        
+        log_named_address("currentItem", currentItem);
+        // log_named_uint("oracleCount", oracleCount);
+
+        // address[] memory trustedOracles = oracleOverlay.trustedOracles;
+        // log_string("initialOracleCount");
+
         targets[0] = govActions;
         calldatas[0] = abi.encodeWithSignature(
-            "executeChange(address)",
-            oracleOverlay
+            "ScheduleChangeTrustedOracle(address,uint8,uint256,address)",
+            oracleOverlay,
+            uint8(1), // "ChangeType: Add"
+            uint256(1), // 0 = Chainlink, 1 = Existing Tellor, 2 = Updated Tellor
+            address(oldTellorOracle)
         );
 
         // propose / execute proposal


### PR DESCRIPTION
Remove the old Tellor oracle once the newly added one is executed. Newly added PR: https://github.com/reflexer-labs/geb-dao-governance-actions/pull/29

Notes:
1. This proposal is 32 to leave room for 31 that will be sued to execute May 2023 incentives.